### PR TITLE
Rename ntnft_token to nft_token to apply standard

### DIFF
--- a/near-contract-standards/src/ntnft/core/core_impl.rs
+++ b/near-contract-standards/src/ntnft/core/core_impl.rs
@@ -229,7 +229,7 @@ impl NTNFT {
 }
 
 impl NTNFTCore for NTNFT {
-    fn ntnft_token(&self, token_id: TokenId) -> Option<Token> {
+    fn nft_token(&self, token_id: TokenId) -> Option<Token> {
         let owner_id = self.owner_by_id.get(&token_id)?;
         let metadata = self.token_metadata_by_id.as_ref().and_then(|by_id| by_id.get(&token_id));
         Some(Token { token_id, owner_id, metadata })

--- a/near-contract-standards/src/ntnft/core/mod.rs
+++ b/near-contract-standards/src/ntnft/core/mod.rs
@@ -13,5 +13,5 @@ use crate::ntnft::token::{Token, TokenId};
 /// [core NTNFT standard]: https://nomicon.io/Standards/NTNFT/Core.html
 pub trait NTNFTCore {
     /// Returns the token with the given `token_id` or `null` if no such token.
-    fn ntnft_token(&self, token_id: TokenId) -> Option<Token>;
+    fn nft_token(&self, token_id: TokenId) -> Option<Token>;
 }


### PR DESCRIPTION
Small change to ensure our impl. which is used as the reference implementation in the NTNFT standard conforms to the standard.

Be aware, the following test will fail in our smart contracts with this change: https://github.com/kycdao/smart-contracts/blob/main/near/kycdao-ntnft/src/lib.rs#L230

Also, the frontend would need to be updated for this change as well presumably.